### PR TITLE
Rename RSSlink to RSSLink

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,7 +8,7 @@
   {{ partial "title" . }}
   <meta name="description" content="{{ .Description }}">
   <link rel="canonical" href="{{ .Permalink }}">
-  <link href="{{ .RSSlink  }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}">
+  <link href="{{ .RSSLink  }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Code+Pro|Arvo:400,700">
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/highlight.css">
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/paperback.css">


### PR DESCRIPTION
The former will be deprecated and eventually removed from Hugo.

Note: Currently both of them exist in Hugo, which is the reason for the cleanup.