### PR TITLE
Replace RSSlink with RSSLink

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,7 +8,7 @@
   {{ partial "title" . }}
   <meta name="description" content="{{ .Description }}">
   <link rel="canonical" href="{{ .Permalink }}">
-  <link href="{{ .RSSlink  }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}">
+  <link href="{{ .RSSLink  }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Code+Pro|Arvo:400,700">
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/highlight.css">
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/paperback.css">


### PR DESCRIPTION
The former is deprecated and now removed from Hugo. Note that the latter will also work in older versions of Hugo.