### PR TITLE
Hugo 0.24 requires date/title in archetype file

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,2 +1,5 @@
-+++
-+++
+---
+title: "{{ replace .TranslationBaseName "-" " " | title }}"
+date: {{ .Date }}
+draft: true
+---


### PR DESCRIPTION
Full error message:

```
WARNING: date and/or title missing from archetype file "/Users/donvince/donvince.com/themes/paperback/archetypes/default.md".
From Hugo 0.24 this must be provided in the archetype file itself, if needed. Example:
---
title: "{{ replace .TranslationBaseName "-" " " | title }}"
date: {{ .Date }}
draft: true
---
```